### PR TITLE
Add instructions for Blinka Pull

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,13 @@ Or the following command to update an existing version:
 
     circup update
 
+Installing for Blinka with Pip
+==============================
+
+.. code-block:: shell
+
+    pip3 install cedargrove-nau7802
+
 Usage Example
 =============
 


### PR DESCRIPTION
Since this can now be downloaded for use in Blinka using PIP3, add instructions for this to the README file.